### PR TITLE
modify: downgraded to nextjs 12.0.9 to resolve image caching error

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "axios": "^0.26.0",
     "classnames": "^2.3.1",
-    "next": "12.0.10",
+    "next": "12.0.9",
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "sass": "^1.49.7"
@@ -21,7 +21,7 @@
     "@types/react": "17.0.39",
     "cypress": "^9.4.1",
     "eslint": "8.9.0",
-    "eslint-config-next": "12.0.10",
+    "eslint-config-next": "12.0.9",
     "eslint-config-prettier": "^8.3.0",
     "typescript": "4.5.5"
   }


### PR DESCRIPTION
## 타입

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Other

## 구현사항
- nextjs image cahing 에러 발생하는 문제를 해결하기 위해 nextjs 12.0.9로 다운그레이드

## 체크리스트

- [x] Linked Issues에서 적절한 이슈 하나를 걸어두었습니다.
- [x] 의도한 파일들과 수정 사항들만 커밋이 된 것을 확인 하였습니다.
- [x] 기능이 제대로 실행되는지 확인 하였습니다.
- [x] npm start로 구현한 화면 혹은 기능을 확인할 수 있습니다.

## 특이 사항
참고 페이지: [https://github.com/vercel/next.js/issues/33860](https://github.com/vercel/next.js/issues/33860)
